### PR TITLE
Add installation of unzip utility to fix Docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM open-liberty as server-setup
 COPY /target/mpservice.zip /config/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip
 RUN unzip /config/mpservice.zip && \
     mv /wlp/usr/servers/mpserviceServer/* /config/ && \
     rm -rf /config/wlp && \


### PR DESCRIPTION
I participated in Open Liberty lab session. Found docker build error. Installing unzip utility in the Dockerfile fixed the error. This fix was tested.